### PR TITLE
update mocka removing jsonpath dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,7 @@ RUN /scripts/lua_rocks.sh \
 
 RUN git config --global url."https://".insteadOf git://
 
-RUN sudo luarocks install jsonpath \
-    && sudo luarocks install lua-cjson 2.1.0-1\
+RUN sudo luarocks install lua-cjson 2.1.0-1\
     && sudo luarocks install lua-ev \
     && sudo luarocks install luabitop \
     && sudo luarocks install lua-resty-iputils

--- a/dist/luarocks/mocka-1.0.0-1.rockspec
+++ b/dist/luarocks/mocka-1.0.0-1.rockspec
@@ -33,8 +33,7 @@ dependencies = {
     "lua-resty-iputils",
     "penlight",
     "ldoc",
-    "luacheck",
-    "jsonpath"
+    "luacheck"
 }
 build = {
 	type = "builtin",


### PR DESCRIPTION
## Description

jsonpath dependency is no longer available in open source mode.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
